### PR TITLE
option to load Tipalti iFrame with specific height

### DIFF
--- a/src/iFrame.php
+++ b/src/iFrame.php
@@ -32,6 +32,11 @@ class iFrame
     ];
 
     /**
+     * Default style for the iFrame
+     */
+    const DEFAULT_STYLE = "border: none; margin-top: 20px; margin-bottom: 20px;";
+
+    /**
      * @param TipaltiPayer $client
      */
     public function __construct(TipaltiPayer $client)
@@ -112,12 +117,13 @@ class iFrame
      * @param string $payeeIdentifier
      * @param array $extraParameters
      * @param string $style
+     * @param int $height
      * @return string
      * @throws Exception
      */
-    public function getiFrameHTML(string $type, string $payeeIdentifier, array $extraParameters = [], string $style = "border: none; margin-top: 20px; margin-bottom: 20px;"): string
+    public function getiFrameHTML(string $type, string $payeeIdentifier, array $extraParameters = [], string $style = self::DEFAULT_STYLE, $height = 200): string
     {
         $url = $this->getiFrameUrl($type, $payeeIdentifier, $extraParameters);
-        return '<iframe width="100%" height="200" style="' . $style . '" src="' . $url . '" id="tipaltiEmbed"></iframe><script>tipaltiiFrameResize=function(t){t.data&&t.data.TipaltiIframeInfo&&t.data.TipaltiIframeInfo.height&&(document.getElementById("tipaltiEmbed").height=t.data.TipaltiIframeInfo.height)},window.addEventListener?window.addEventListener("message",tipaltiiFrameResize,!1):window.attachEvent("onmessage",tipaltiiFrameResize);</script>';
+        return '<iframe width="100%" height="' . $height . '" style="' . $style . '" src="' . $url . '" id="tipaltiEmbed"></iframe><script>tipaltiiFrameResize=function(t){t.data&&t.data.TipaltiIframeInfo&&t.data.TipaltiIframeInfo.height&&(document.getElementById("tipaltiEmbed").height=t.data.TipaltiIframeInfo.height)},window.addEventListener?window.addEventListener("message",tipaltiiFrameResize,!1):window.attachEvent("onmessage",tipaltiiFrameResize);</script>';
     }
 }

--- a/src/iFrame.php
+++ b/src/iFrame.php
@@ -34,7 +34,7 @@ class iFrame
     /**
      * Default style for the iFrame
      */
-    const DEFAULT_STYLE = "border: none; margin-top: 20px; margin-bottom: 20px;";
+    public const DEFAULT_STYLE = "border: none; margin-top: 20px; margin-bottom: 20px;";
 
     /**
      * @param TipaltiPayer $client


### PR DESCRIPTION
Adding an option to load Tipalti iFrame with specific height.
The default one is still 200, but on AB publisher portals, Invoice History and Payment Settings pages look weird with lots of data and small iFrame scrolling.
Here are the before:
![Screenshot 2023-12-11 at 13 28 07](https://github.com/nextnetmedia/tipalti-chipotle/assets/3720863/4530ae14-7020-47d9-9451-dde959852bea)
And after (when modified the iframe element in the dev tools):
![Screenshot 2023-12-11 at 13 29 03](https://github.com/nextnetmedia/tipalti-chipotle/assets/3720863/30f33820-dbd1-4c6c-86aa-2f4dff0eed9f)
